### PR TITLE
Fix find command to be consistent with the documented behavior in User Guide

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -45,7 +45,7 @@ e.g. typing help and pressing Enter will open the help window.
 
 * *`list`* : lists all employees.
 * **`add`**`-n John Doe -p 98765432 -e johnd@example.com -a 311, Clementi Ave 2, #02-25 -s 10000` : adds an employee named John Doe with the email johnd@example.com, the address 311, Clementi Ave 2, #02-25, with a salary of 10,000.
-* **`find`**`J*` : finds all employees that start with J.
+* **`find`**`J*` : finds all employees where any of their names start with J.
 * *`exit`* : exits the app
 
 .  Refer to <<Commands>> for details of each command.
@@ -214,7 +214,7 @@ Search and display all employees that match the given name criteria.
 Format: `find NAME`
 
 ****
-* NAME can be any name or parts of name.
+* NAME can be any name or parts of name that are separated by whitespace (such as a space charaacter).
 * You can use the * character to match any number of characters (0 or more)
 * You can also use the _ character to match any single character
 * Find is case insensitive
@@ -222,11 +222,11 @@ Format: `find NAME`
 
 Examples:
 
-* `find jian yu`: Displays everyone that has 'jian' or 'yu' in their name
+* `find jian yu`: Displays everyone whose names contain "jian" or "yu", surrounded by whitespace.
 
-* `find d*` Displays everyone whose's names start with d.
+* `find d*` Displays all employees where any of their names start with d.
 
-* 'find T_m' Displays 'Tom' and 'Tim', but not 'Tian'
+* `find T_m` Displays 'Tom' and 'tim', but not 'Tian'
 
 === Edit details : `edit`
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -19,9 +19,11 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         for (String aKeyword : keywords) {
             String newKeyword = aKeyword.toLowerCase()
                                         .replace('_', '.').replace("*", ".*");
-            newKeyword = ".*" + newKeyword + ".*";
-            if (person.getName().fullName.toLowerCase().matches(newKeyword)) {
-                return true;
+            String[] nameParts = person.getName().fullName.toLowerCase().split("\\W");
+            for (String s : nameParts) {
+                if (s.matches(newKeyword)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Currently, User Guide behavior says that the find command should only find people who's names start with J if we run **find J\***. However, this is not the case, as the resulting query is wrapped around *, so it will actually find anyone who's name contains J.

I removed the check, instead opting to compare by name parts (delimited with whitespace). Updated documentation to reflect this change.