### PR TITLE
Changed error message for login as admin

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -122,11 +122,16 @@ public class LogicManager extends ComponentManager implements Logic {
         String username = loginEvent.getUsername();
         String password = loginEvent.getPassword();
 
-        if (User.matchesAdminLogin(username, password)) {
-            User admin = User.getAdminUser();
-            model.setLoggedInUser(admin);
-            raise(new SuccessfulLoginEvent(admin));
-            return;
+        if (username.equals(User.getAdminUser().getUsername().username)) {
+            if (User.matchesAdminLogin(username, password)) {
+                User admin = User.getAdminUser();
+                model.setLoggedInUser(admin);
+                raise(new SuccessfulLoginEvent(admin));
+                return;
+            } else {
+                raise(new FailedLoginEvent(FailedLoginEvent.INVALID_PASSWORD));
+                return;
+            }
         }
 
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);

--- a/src/test/java/seedu/address/logic/LoginTest.java
+++ b/src/test/java/seedu/address/logic/LoginTest.java
@@ -42,6 +42,16 @@ public class LoginTest {
     }
 
     @Test
+    public void login_admin_unsuccessful() {
+        String adminUsername = User.ADMIN_DEFAULT_USERNAME.username;
+        String adminPassword = User.ADMIN_DEFUALT_PASSWORD.password;
+
+        EventsCenter.getInstance().post(new LoginEvent(adminUsername, adminPassword + "hihihi"));
+
+        assertLastEventLoginUnsuccessful(FailedLoginEvent.INVALID_PASSWORD);
+    }
+
+    @Test
     public void login_user_successful() {
         Person loginPerson = model.getAddressBook().getPersonList().get(0);
         String username = loginPerson.getUsername().username;
@@ -60,7 +70,7 @@ public class LoginTest {
 
         EventsCenter.getInstance().post(new LoginEvent(username, password));
 
-        assertLastEventLogoutUnsuccessful(FailedLoginEvent.NON_CONFORMING_INPUTS);
+        assertLastEventLoginUnsuccessful(FailedLoginEvent.NON_CONFORMING_INPUTS);
     }
 
     @Test
@@ -89,7 +99,7 @@ public class LoginTest {
 
         EventsCenter.getInstance().post(new LoginEvent(username, password));
 
-        assertLastEventLogoutUnsuccessful(FailedLoginEvent.INVALID_USERNAME);
+        assertLastEventLoginUnsuccessful(FailedLoginEvent.INVALID_USERNAME);
     }
 
     @Test
@@ -100,7 +110,7 @@ public class LoginTest {
 
         EventsCenter.getInstance().post(new LoginEvent(username, password));
 
-        assertLastEventLogoutUnsuccessful(FailedLoginEvent.INVALID_PASSWORD);
+        assertLastEventLoginUnsuccessful(FailedLoginEvent.INVALID_PASSWORD);
     }
 
     /**
@@ -115,9 +125,9 @@ public class LoginTest {
 
     /**
      * Verifies that the login was unsuccessful, and for a certain reason
-     * @param reason The logout Event's message
+     * @param reason The Failed Login Event's message
      */
-    private void assertLastEventLogoutUnsuccessful(String reason) {
+    private void assertLastEventLoginUnsuccessful(String reason) {
         BaseEvent lastEvent = eventsCollectorRule.eventsCollector.getMostRecent();
         assert lastEvent instanceof FailedLoginEvent;
         FailedLoginEvent failedLoginEvent = (FailedLoginEvent) lastEvent;


### PR DESCRIPTION
Fixes #151.

This checks if the username is Admin and prints "Wrong password!" if password is wrong.

This is ok now as opposed to in V1.3 because with #148, no user can have the username "Admin".